### PR TITLE
You don't want to use undoable actions if you don't have to

### DIFF
--- a/resources/workflow-undoing-changes.bmml
+++ b/resources/workflow-undoing-changes.bmml
@@ -200,7 +200,7 @@
                 </control>
                 <control controlID="25" controlTypeID="com.balsamiq.mockups::Button" x="241" y="948" w="-1" h="-1" measuredW="92" measuredH="27" zOrder="25" locked="false" isInGroup="0">
                   <controlProperties>
-                    <text>reset%20--hard</text>
+                    <text>git%20%stash%20--all</text>
                   </controlProperties>
                 </control>
                 <control controlID="26" controlTypeID="com.balsamiq.mockups::Button" x="225" y="1112" w="-1" h="-1" measuredW="125" measuredH="27" zOrder="26" locked="false" isInGroup="0">


### PR DESCRIPTION
`git reset --hard` is one of the most dangerous commands because it will permanently destroy work. If you do this by accident, your work is _gone_.

The safer way to do this is with `git stash -a` or `git stash save --all` to be explicit. The stash is not going to be pushed up so it won't bloat any repositories.

`git reset --hard` is not like handing a toddler scissors, it's like handing them a gun. We should not be teaching this to new git users.