### PR TITLE
typo / spelling in oscon workshop slide

### DIFF
--- a/slides/slides/workshop-oscon-gitforteams.md
+++ b/slides/slides/workshop-oscon-gitforteams.md
@@ -474,7 +474,7 @@ github.com/gitforteams/gitforteams
 - [Deployment](../../resources/workflow-sample-whisperingpines-deployment.md)
 
 
-## Penultiate Activity: Sketch Your Workflow
+## Penultimate Activity: Sketch Your Workflow
 
 - Restructure your previous diagrams to include the intrastate where code is collated.
 - Add arrows to represent the direction code travels.


### PR DESCRIPTION
Simple typo / spelling correction of Penultimate in the penultimate subtitle of an oscon workshop slide. Thanks.